### PR TITLE
#168249624 Reporter can update reported Incident 

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -1,7 +1,7 @@
 class IncidentsController < ApplicationController
-  before_action :set_incident, only: :show
+  before_action :set_incident, only: [:show, :update]
   def create
-    @incident = current_user.reported_incidents.create!(incident_params)
+    @incident = current_user.reported_incidents.create!(create_params)
     response = {
       message: Message.report_success,
       data: @incident
@@ -12,11 +12,27 @@ class IncidentsController < ApplicationController
   def show
     json_response({ data: @incident }, :ok)
   end
+
+  def update
+    return json_response({ error: Message.unauthorized }, 401) unless @incident[:reporter_id] == current_user.id
+    return json_response({ error: Message.update_failure }, 422) unless @incident[:status] == "draft"
+
+    @incident.update(update_params)
+    response = {
+      message: Message.update_success,
+      data: @incident
+    }
+    json_response(response, :ok)
+  end
   
   private
 
-  def incident_params
+  def create_params
     params.permit(:title, :evidence, :narration, :location, :status, :incident_type_id)
+  end
+
+  def update_params
+    params.permit(:title, :evidence, :narration, :location, :incident_type_id)
   end
 
   def set_incident

--- a/app/lib/message.rb
+++ b/app/lib/message.rb
@@ -38,4 +38,12 @@ class Message
   def self.report_success
     'Incident was reported successfully'
   end
+
+  def self.update_success
+    'Incident was updated successfully'
+  end
+
+  def self.update_failure
+    'Only Incidents marked as draft, can be updated'
+  end
 end

--- a/spec/requests/incidents_spec.rb
+++ b/spec/requests/incidents_spec.rb
@@ -9,15 +9,16 @@ RSpec.describe 'Incidents', type: :request do
       "Content-Type" => "application/json"
     }
   end
-  let(:valid_attributes) { attributes_for(:incident) } 
+  let(:valid_attributes) { attributes_for(:incident) }
+
+  before do
+    valid_attributes[:reporter_id] = reporter.id
+    valid_attributes[:incident_type_id] = incident_type.id
+  end
   
   describe 'POST #create' do
     context 'when valid request' do
-      before do
-        valid_attributes[:reporter_id] = reporter.id
-        valid_attributes[:incident_type_id] = incident_type.id
-        post '/incidents', params: valid_attributes.to_json, headers: headers
-      end
+      before { post '/incidents', params: valid_attributes.to_json, headers: headers }
 
       it 'creates a new incident' do
         expect(response).to have_http_status(201)
@@ -49,7 +50,7 @@ RSpec.describe 'Incidents', type: :request do
         get "/incidents/#{incident.id}", headers: headers
       end
 
-      it 'returns an ok response' do
+      it 'returns an ok status' do
         expect(response).to have_http_status(200)
       end
 
@@ -61,12 +62,65 @@ RSpec.describe 'Incidents', type: :request do
     context 'when invalid request' do
       before { get '/incidents/1', headers: headers }
 
-      it 'returns an ok response' do
+      it 'returns an not found status' do
         expect(response).to have_http_status(404)
       end
 
       it 'returns an incident' do
         expect(json_response[:error]).to match(/Couldn't find Incident/)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'when valid request' do
+      let(:incident) { create(:incident, reporter_id: reporter.id, incident_type_id: incident_type.id) }
+
+      before { put "/incidents/#{incident.id}", params: valid_attributes.to_json, headers: headers }
+
+      it 'returns an ok response' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns a success message' do
+        expect(json_response[:message]).to match(/Incident was updated successfully/)
+      end
+
+      it 'returns the updated incident' do
+        expect(json_response[:data]).not_to be_nil
+      end
+    end
+
+    context 'when invalid request' do
+      let(:incident) { 
+        create(:incident, status: "resolved", reporter_id: reporter.id, incident_type_id: incident_type.id)
+      }
+
+      before { put "/incidents/#{incident.id}", params: valid_attributes.to_json, headers: headers }
+
+      it 'returns a unprocessable status' do
+        expect(response).to have_http_status(422)
+      end
+
+      it 'returns a success message' do
+        expect(json_response[:error]).to match(/Only Incidents marked as draft, can be updated/)
+      end
+    end
+
+    context 'when invalid request' do
+      let(:reporterx) { create(:reporterx) }
+      let(:incident) { 
+        create(:incident, reporter_id: reporterx.id, incident_type_id: incident_type.id)
+      }
+
+      before { put "/incidents/#{incident.id}", params: valid_attributes.to_json, headers: headers }
+
+      it 'returns a unprocessable status' do
+        expect(response).to have_http_status(401)
+      end
+
+      it 'returns a success message' do
+        expect(json_response[:error]).to match(/Unauthorized request/)
       end
     end
   end


### PR DESCRIPTION
#### What does this PR do?
This PR ensures users (or reporters) can update their reported incidents on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Open `Postman`
- Sign-up or Login to the application
- Ensure you have or created an Incident report in the database.
- Send a PUT request to `localhost:4000/incidents/:id`; with valid parameters to update.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168249624](https://www.pivotaltracker.com/story/show/168249624)