### PR TITLE
#168249657 Reporter can delete reported incidents

### DIFF
--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -1,5 +1,6 @@
 class IncidentsController < ApplicationController
-  before_action :set_incident, only: [:show, :update]
+  before_action :set_incident, except: :create
+
   def create
     @incident = current_user.reported_incidents.create!(create_params)
     response = {
@@ -14,8 +15,8 @@ class IncidentsController < ApplicationController
   end
 
   def update
-    return json_response({ error: Message.unauthorized }, 401) unless @incident[:reporter_id] == current_user.id
-    return json_response({ error: Message.update_failure }, 422) unless @incident[:status] == "draft"
+    return json_response({ error: Message.unauthorized }, 401) unless my_incident?(@incident)
+    return json_response({ error: Message.update_failure }, 422) unless draft_incident?(@incident)
 
     @incident.update(update_params)
     response = {
@@ -23,6 +24,14 @@ class IncidentsController < ApplicationController
       data: @incident
     }
     json_response(response, :ok)
+  end
+
+  def destroy
+    return json_response({ error: Message.unauthorized }, 401) unless my_incident?(@incident)
+    return json_response({ error: Message.delete_failure }, 422) unless draft_incident?(@incident)
+
+    @incident.destroy
+    json_response({ message: Message.delete_success }, :ok)
   end
   
   private
@@ -37,5 +46,13 @@ class IncidentsController < ApplicationController
 
   def set_incident
     @incident = Incident.find(params[:id])
+  end
+
+  def my_incident?(incident)
+    incident[:reporter_id] == current_user.id
+  end
+
+  def draft_incident?(incident)
+    incident[:status] == "draft"
   end
 end

--- a/app/lib/message.rb
+++ b/app/lib/message.rb
@@ -43,7 +43,15 @@ class Message
     'Incident was updated successfully'
   end
 
+  def self.delete_success
+    'Incident was deleted successfully'
+  end
+
   def self.update_failure
     'Only Incidents marked as draft, can be updated'
+  end
+
+  def self.delete_failure
+    'Only Incidents marked as draft, can be deleted'
   end
 end


### PR DESCRIPTION
#### What does this PR do?
This PR ensures users (or reporters) can delete their reported incidents on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Open `Postman`
- Sign-up or Login to the application
- Ensure you have or created an Incident report in the database.
- Send a DELETE request to `localhost:4000/incidents/:id`; with valid parameters to update.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168249657](https://www.pivotaltracker.com/story/show/168249657)