### PR TITLE
#168249583 Admin can update incident report's status

### DIFF
--- a/db/migrate/20190926205639_add_admin_to_reporters.rb
+++ b/db/migrate/20190926205639_add_admin_to_reporters.rb
@@ -1,0 +1,5 @@
+class AddAdminToReporters < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reporters, :is_admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_14_133912) do
+ActiveRecord::Schema.define(version: 2019_09_26_205639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_09_14_133912) do
     t.text "avatar"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_admin", default: false
   end
 
   add_foreign_key "follows", "incidents", column: "following_id", on_delete: :cascade


### PR DESCRIPTION
#### What does this PR do?
This PR ensures admins can update the status of reported incidents on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Run `rails db:migrate` in the 
- Open `Postman`
- Sign-up or Login to the application, as Admin
- Ensure you have or created an Incident report in the database.
- Send a PUT request to `localhost:4000/incidents/:id`; with a valid status to update.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168249583](https://www.pivotaltracker.com/story/show/168249583)