### PR TITLE
#168250436 Reporter can follow/unfollow an Incident report

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,16 @@
+class FollowsController < ApplicationController
+  def create 
+    @follow = current_user.follows.find_by(following_id: params[:incident_id])
+    if @follow
+      @follow.destroy
+      return json_response({ message: Message.unfollow_success }, :ok)
+    end
+
+    @follow = current_user.follows.create!(following_id: params[:incident_id])
+    response = {
+      message: Message.follow_success,
+      data: @follow
+    }
+    json_response(response, :created)
+  end
+end

--- a/app/lib/message.rb
+++ b/app/lib/message.rb
@@ -54,4 +54,12 @@ class Message
   def self.delete_failure
     'Only Incidents marked as draft, can be deleted'
   end
+
+  def self.follow_success
+    'Incident followed successfully'
+  end
+
+  def self.unfollow_success
+    'Incident unfollowed successfully'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
   post 'signup', to: 'reporters#create'
   post 'login', to: 'authentication#authenticate'
 
-  resources :incidents
+  resources :incidents do
+    resources :follows, only: [:create, :index]
+    resources :comments
+  end
 end

--- a/spec/factories/follow.rb
+++ b/spec/factories/follow.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :follow do
-    follower_id
-    following_id
+    follower_id { 1 }
+    following_id { 1 }
   end
 end

--- a/spec/factories/reporter.rb
+++ b/spec/factories/reporter.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :reporter do
+  factory :reporter, aliases: [:reporterx] do
     name { Faker::Name.first_name }
     email { Faker::Internet.email }
     password { Faker::Lorem.word }
@@ -7,15 +7,10 @@ FactoryBot.define do
     location { Faker::Lorem.sentence(40) }
     bio { Faker::Lorem.sentence(120) }
     avatar { Faker::Internet.url }
-  end
+    is_admin { false }
 
-  factory :reporterx, class: Reporter do
-    name { Faker::Name.first_name }
-    email { "default@default.com" }
-    password { Faker::Lorem.word }
-    phone { Faker::PhoneNumber.phone_number }
-    location { Faker::Lorem.sentence(40) }
-    bio { Faker::Lorem.sentence(120) }
-    avatar { Faker::Internet.url }
+    factory :admin do
+      is_admin { true }
+    end
   end
 end

--- a/spec/requests/follows_spec.rb
+++ b/spec/requests/follows_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Follows', type: :request do
+  let(:reporter) { create(:reporter) }
+  let(:incident_type) { create(:incident_type) }
+  let(:incident) { create(:incident, reporter_id: reporter.id, incident_type_id: incident_type.id) }
+  let(:headers) do
+    {
+      "Authorization" => token_generator(reporter.id),
+      "Content-Type" => "application/json"
+    }
+  end
+
+  describe 'POST #create' do
+    context 'when valid follow request' do
+      before { post "/incidents/#{incident.id}/follows", headers: headers }
+
+      it 'return a created status' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'return a success message' do
+        expect(json_response[:message]).to match(/Incident followed successfully/)
+      end
+
+      it 'returns the follow data' do
+        expect(json_response[:data]).not_to be_nil
+      end
+    end
+
+    context 'when valid unfollow request' do
+      let!(:follow) { create(:follow, follower_id: reporter.id, following_id: incident.id) }
+      before { post "/incidents/#{incident.id}/follows", headers: headers }
+
+      it 'return a created status' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'return a success message' do
+        expect(json_response[:message]).to match(/Incident unfollowed successfully/)
+      end
+
+      it 'returns the no data' do
+        expect(json_response[:data]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/incidents_spec.rb
+++ b/spec/requests/incidents_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Incidents', type: :request do
   end
 
   describe 'PUT #update' do
-    context 'when valid request' do
+    context 'when valid request for user' do
       let(:incident) { create(:incident, reporter_id: reporter.id, incident_type_id: incident_type.id) }
 
       before { put "/incidents/#{incident.id}", params: valid_attributes.to_json, headers: headers }
@@ -88,6 +88,31 @@ RSpec.describe 'Incidents', type: :request do
 
       it 'returns the updated incident' do
         expect(json_response[:data]).not_to be_nil
+      end
+    end
+
+    context 'when valid request for admin' do
+      let(:incident) { create(:incident, reporter_id: reporter.id, incident_type_id: incident_type.id) }
+      let(:admin) { create(:admin) }
+      let(:headers) do
+        {
+          "Authorization" => token_generator(admin.id),
+          "Content-Type" => "application/json"
+        }
+      end
+
+      before { put "/incidents/#{incident.id}", params: { status: "investigating" }.to_json, headers: headers }
+
+      it 'returns an ok response' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns a success message' do
+        expect(json_response[:message]).to match(/Incident was updated successfully/)
+      end
+
+      it 'returns the updated incident' do
+        expect(json_response[:data][:status]).to match(/investigating/)
       end
     end
 


### PR DESCRIPTION
#### What does this PR do?
This PR ensures reporters(or users) can follow/unfollow reported incidents on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Open `Postman`
- Sign-up or Login to the application
- Ensure you have or created an Incident report in the database.
- Send a POST request to `localhost:4000/incidents/:incident_id/follows`; to follow
- try the above step again, to unfollow

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168250436](https://www.pivotaltracker.com/story/show/168250436)