### PR TITLE
#168249810 Reporters can search for Incidents with keywords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'cloudinary'
 gem 'pry', '~> 0.12.2'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+# Use Elastic Search API as search engine
+gem 'elasticsearch-model'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -56,6 +58,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'faker', '~> 1.6', '>= 1.6.6'
   gem 'database_cleaner'
+  gem 'elasticsearch-extensions'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ansi (1.5.0)
     arel (9.0.0)
     aws_cf_signer (0.1.3)
     bcrypt (3.1.13)
@@ -68,6 +69,21 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    elasticsearch (7.3.0)
+      elasticsearch-api (= 7.3.0)
+      elasticsearch-transport (= 7.3.0)
+    elasticsearch-api (7.3.0)
+      multi_json
+    elasticsearch-extensions (0.0.31)
+      ansi
+      elasticsearch
+    elasticsearch-model (7.0.0)
+      activesupport (> 3)
+      elasticsearch (> 1)
+      hashie
+    elasticsearch-transport (7.3.0)
+      faraday
+      multi_json
     erubi (1.8.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -76,11 +92,14 @@ GEM
       railties (>= 4.2.0)
     faker (1.9.6)
       i18n (>= 0.7)
+    faraday (0.16.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     figaro (1.1.1)
       thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (3.6.0)
     hirb (0.7.3)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -112,6 +131,8 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.1)
+    multi_json (1.13.1)
+    multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.5.1)
     nokogiri (1.10.4)
@@ -212,6 +233,8 @@ DEPENDENCIES
   carrierwave
   cloudinary
   database_cleaner
+  elasticsearch-extensions
+  elasticsearch-model
   factory_bot_rails
   faker (~> 1.6, >= 1.6.6)
   figaro

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::API
   before_action :authorize_request
   attr_reader :current_user
 
+  def is_admin?
+    current_user.is_admin
+  end
+
   private
 
   def authorize_request

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -1,4 +1,9 @@
+require 'elasticsearch/model'
+
 class Incident < ApplicationRecord
+  include Elasticsearch::Model
+  include Elasticsearch::Model::Callbacks
+
   validates :title, presence: true, length: { maximum: 100 }
   validates :evidence, presence: true
   validates :narration, presence: true, length: { maximum: 400 }
@@ -14,4 +19,16 @@ class Incident < ApplicationRecord
 
   # uploader was disabled for testing in Postman
   # mount_uploader :evidence, EvidenceUploader
+
+  def as_indexed_json(options = {})
+    self.as_json(
+      only: [:title, :location, :narration, :status],
+      include: {
+        reporter: { only: :name },
+        incident_type: { only: :title }
+      }
+    )
+  end
+
+  index_name "incidents-#{Rails.env}"
 end

--- a/app/models/incident_type.rb
+++ b/app/models/incident_type.rb
@@ -1,5 +1,13 @@
 class IncidentType < ApplicationRecord
+  after_save :index_incidents_in_elasticsearch
+
   validates :title, presence: true
 
   has_many :incidents
+
+  private
+
+  def index_incidents_in_elasticsearch
+    incidents.find_each { |incident| incident.__elasticsearch__.index_document }
+  end
 end

--- a/app/models/reporter.rb
+++ b/app/models/reporter.rb
@@ -1,4 +1,5 @@
 class Reporter < ApplicationRecord
+  after_save :index_incidents_in_elasticsearch
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   has_secure_password
 
@@ -12,4 +13,10 @@ class Reporter < ApplicationRecord
   has_many :followed_incidents, through: :follows, source: :follower
 
   mount_uploader :avatar, AvatarUploader
+
+  private
+
+  def index_incidents_in_elasticsearch
+    reported_incidents.find_each { |incident| incident.__elasticsearch__.index_document }
+  end
 end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,1 @@
+Elasticsearch::Model.client = Elasticsearch::Client.new host: ENV['ELASTICSEARCH_URL'] || "localhost:9200"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
   post 'signup', to: 'reporters#create'
   post 'login', to: 'authentication#authenticate'
 
+  get 'search', to: 'incidents#search'
   resources :incidents do
     resources :follows, only: [:create, :index]
-    resources :comments
+    resources :comments, except: [:show, :update]
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Incident.__elasticsearch__.create_index!(force: true)
+
+reporter_1 = Reporter.create!(name: 'Efe Agare', email: 'efe.agare@mail.com', password: 'password')
+reporter_2 = Reporter.create!(name: 'Ibidapo Rasheed', email: 'ibidapo.rasheed@mail.com', password: 'password')
+
+Incident.create!(title: 'Xenephobia', location: 'South Africa', narration: 'Xenephobic attacks in SA', status: 'investigating', evidence: 'nothing yet', reporter_id: reporter_1.id, incident_type_id: 1)
+Incident.create!(title: 'Xenephobia', location: 'Nigeria', narration: 'Retaliation to Xenephobic attacks in SA', status: 'investigating', evidence: 'nothing yet', reporter_id: reporter_1.id, incident_type_id: 2)
+Incident.create!(title: 'Xenephobia', location: 'South Africa', narration: 'Xenephobic attacks in SA', status: 'investigating', evidence: 'nothing yet', reporter_id: reporter_2.id, incident_type_id: 1)
+Incident.create!(title: 'Xenephobia', location: 'Nigeria', narration: 'Retaliation to Xenephobic attacks in SA', status: 'investigating', evidence: 'nothing yet', reporter_id: reporter_2.id, incident_type_id: 2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,48 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'elasticsearch/extensions/test/cluster'
+
 RSpec.configure do |config|
+  # Start an in-memory cluster for Elasticsearch as needed
+  config.before :all, elasticsearch: true do
+    Elasticsearch::Extensions::Test::Cluster.start(port: 9250, nodes: 1, timeout: 120) unless Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
+  end
+
+  # Stop elasticsearch cluster after test run
+  config.after :suite do
+    Elasticsearch::Extensions::Test::Cluster.stop(port: 9250, nodes: 1) if Elasticsearch::Extensions::Test::Cluster.running?(on: 9250)
+  end
+
+  # Create indexes for all elastic searchable models
+  config.before :each, elasticsearch: true do
+    if Incident.respond_to?(:__elasticsearch__)
+      begin
+        Incident.__elasticsearch__.create_index!
+        Incident.__elasticsearch__.refresh_index!
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        # This kills "Index does not exist" errors being written to console
+        # by this: https://github.com/elastic/elasticsearch-rails/blob/738c63efacc167b6e8faae3b01a1a0135cfc8bbb/elasticsearch-model/lib/elasticsearch/model/indexing.rb#L268
+      rescue => e
+        STDERR.puts "There was an error creating the elasticsearch index for Incident: #{e.inspect}"
+      end
+    end
+  end
+
+  # Delete indexes for all elastic searchable models to ensure clean state between tests
+  config.after :each, elasticsearch: true do
+    if Incident.respond_to?(:__elasticsearch__)
+      begin
+        Incident.__elasticsearch__.delete_index!
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        # This kills "Index does not exist" errors being written to console
+        # by this: https://github.com/elastic/elasticsearch-rails/blob/738c63efacc167b6e8faae3b01a1a0135cfc8bbb/elasticsearch-model/lib/elasticsearch/model/indexing.rb#L268
+      rescue => e
+        STDERR.puts "There was an error removing the elasticsearch index for Incident: #{e.inspect}"
+      end
+    end
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
#### What does this PR do?
This PR ensures Reporters (or Users) can search or filter for Incident reports using keywords related to the Incident, Incident Type and Incident Reporter

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Delete the records on reporters and Incidents table.
- run `elasticsearch` in the terminal
- run `rails db:seed` in the terminal to seed data into the database
- Login or Sign-up to the app.
- Send a GET request to localhost:4000/search; with a query params as the search term 

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168249810](https://www.pivotaltracker.com/story/show/168249810)