### PR TITLE
#169156664 Reporter can delete their replies to comments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,10 @@ class ApplicationController < ActionController::API
     current_user.is_admin
   end
 
+  def is_mine?(obj)
+    obj[:reporter_id] == current_user.id
+  end
+
   private
 
   def authorize_request

--- a/app/controllers/comment_replies_controller.rb
+++ b/app/controllers/comment_replies_controller.rb
@@ -1,5 +1,6 @@
 class CommentRepliesController < ApplicationController
-  before_action :check_incident_comment, except: :index
+  before_action :check_incident_comment, only: :create
+  before_action :set_comment_reply, except: :create
 
   def create
     @comment_reply = CommentReply.create!(
@@ -14,10 +15,22 @@ class CommentRepliesController < ApplicationController
     }, :created)
   end
 
+  def destroy
+    return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@comment_reply) || is_admin?
+
+    @comment_reply.destroy
+    json_response({ message: Message.delete_success('Reply') }, :ok)
+  end
+
   private
 
   def check_incident_comment
-    @incident = Incident.find(params[:incident_id])
-    @comment = @incident.comments.find(params[:comment_id])
+    incident = Incident.find(params[:incident_id])
+    incident.comments.find(params[:comment_id])
+  end
+
+  def set_comment_reply
+    comment = check_incident_comment()
+    @comment_reply = comment.comment_replies.find(params[:id])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -28,7 +28,7 @@ class CommentsController < ApplicationController
     return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@comment) || is_admin?
 
     @comment.destroy
-    json_response({ message: Message.delete_success("Comment")}, :ok)
+    json_response({ message: Message.delete_success('Comment')}, :ok)
   end
 
   private
@@ -36,9 +36,5 @@ class CommentsController < ApplicationController
   def set_comment
     @incident = Incident.find(params[:incident_id])
     @comment = @incident.comments.find(params[:id])
-  end
-
-  def is_mine?(comment)
-    comment[:reporter_id] == current_user.id
   end
 end

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -27,8 +27,8 @@ class IncidentsController < ApplicationController
   end
 
   def update
-    return json_response({ error: Message.unauthorized }, 401) unless my_incident?(@incident) || is_admin?
-    return json_response({ error: Message.update_failure }, 422) unless draft_incident?(@incident) || is_admin?
+    return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@incident) || is_admin?
+    return json_response({ error: Message.update_failure }, 422) unless is_draft?(@incident) || is_admin?
 
     update_params = if is_admin? then update_status_params else update_all_params end
     @incident.update(update_params)
@@ -45,11 +45,11 @@ class IncidentsController < ApplicationController
   end
 
   def destroy
-    return json_response({ error: Message.unauthorized }, 401) unless my_incident?(@incident)
-    return json_response({ error: Message.delete_failure }, 422) unless draft_incident?(@incident)
+    return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@incident) || is_admin?
+    return json_response({ error: Message.delete_failure }, 422) unless is_draft?(@incident) || is_admin?
 
     @incident.destroy
-    json_response({ message: Message.delete_success("Incident") }, :ok)
+    json_response({ message: Message.delete_success('Incident') }, :ok)
   end
 
   def search
@@ -83,11 +83,7 @@ class IncidentsController < ApplicationController
     @incident = Incident.find(params[:id])
   end
 
-  def my_incident?(incident)
-    incident[:reporter_id] == current_user.id
-  end
-
-  def draft_incident?(incident)
+  def is_draft?(incident)
     incident[:status] == "draft"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
   get 'search', to: 'incidents#search'
   resources :incidents do
     resources :follows, only: [:create, :index]
-    resources :comments, except: [:show] do
-      resources :comment_replies, except: [:show, :update]
+    resources :comments, except: [:show, :index] do
+      resources :comment_replies, except: [:show, :index]
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do?
This PR ensures users (or reporters) can delete their replies to comments on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Open `Postman`
- Sign-up or Login to the application
- Ensure you have or created an Incident report with a comment and comment reply in the database.
- Send a `DELETE` request to `localhost:4000/incidents/:incident_id/comments/:comment_id/comment_replies/:id`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#169156664](https://www.pivotaltracker.com/story/show/169156664)