### PR TITLE
#168964249 Reporter can update their reply to comment

### DIFF
--- a/app/controllers/comment_replies_controller.rb
+++ b/app/controllers/comment_replies_controller.rb
@@ -15,6 +15,16 @@ class CommentRepliesController < ApplicationController
     }, :created)
   end
 
+  def update
+    return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@comment_reply)
+    @comment_reply.update!(body: params[:body])
+    
+    json_response({
+      message: Message.update_success('Reply'),
+      data: @comment_reply
+    }, :ok)
+  end
+
   def destroy
     return json_response({ error: Message.unauthorized }, 401) unless is_mine?(@comment_reply) || is_admin?
 

--- a/spec/requests/comment_replies_spec.rb
+++ b/spec/requests/comment_replies_spec.rb
@@ -43,6 +43,41 @@ RSpec.describe 'CommentReplies',  type: :request do
     end
   end
 
+  describe 'PUT #update' do
+    let(:comment_reply) { create(:comment_reply, comment_id: comment.id, reporter_id: reporter.id) }
+
+    context 'when valid request for user' do
+      before { put "/incidents/#{incident.id}/comments/#{comment.id}/comment_replies/#{comment_reply.id}", params: valid_attributes.to_json, headers: headers }
+
+      it 'returns an ok response' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns a success message' do
+        expect(json_response[:message]).to match(/Reply was updated successfully/)
+      end
+
+      it 'returns the updated incident' do
+        expect(json_response[:data][:id]).to eq(comment_reply.id)
+      end
+    end
+
+    context 'when invalid request for another user' do
+      let(:reporterx) { create(:reporterx) }
+      let(:comment_reply) { create(:comment_reply, comment_id: comment.id, reporter_id: reporterx.id) }
+
+      before { put "/incidents/#{incident.id}/comments/#{comment.id}/comment_replies/#{comment_reply.id}", params: valid_attributes.to_json, headers: headers}
+
+      it 'returns a unprocessable status' do
+        expect(response).to have_http_status(401)
+      end
+
+      it 'returns an error message' do
+        expect(json_response[:error]).to match(/Unauthorized request/)
+      end
+    end
+  end
+
   describe 'DELETE #destroy' do
     let(:comment_reply) { create(:comment_reply, comment_id: comment.id, reporter_id: reporter.id) }
 


### PR DESCRIPTION
#### What does this PR do?
This PR ensures users (or reporters) can update their replies to comments on the application

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
- Checkout to this branch
- Open `Postman`
- Sign-up or Login to the application
- Ensure you have or created an Incident report with a comment and comment reply in the database.
- Send a `PUT` request to `localhost:4000/incidents/:incident_id/comments/:comment_id/comment_replies/:id`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#168964249](https://www.pivotaltracker.com/story/show/168964249)